### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/ByteTheBarrier/a9b6a745-823d-4e4f-8ac2-61d177782e14/f115c5b9-5b7b-4306-945c-4c7da9982cf4/_apis/work/boardbadge/45c02f84-2efd-4c26-bbd3-182220ad9ce5)](https://dev.azure.com/ByteTheBarrier/a9b6a745-823d-4e4f-8ac2-61d177782e14/_boards/board/t/f115c5b9-5b7b-4306-945c-4c7da9982cf4/Microsoft.RequirementCategory)
 # MSc Final Project Group 3: The Accessibilator


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/ByteTheBarrier/a9b6a745-823d-4e4f-8ac2-61d177782e14/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.